### PR TITLE
fix(changelog): drop the duplicated scaffold line

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,4 +17,3 @@ ready for a dated entry.
 - 2026-05-29 ai-wip: add CodeQL SAST workflow (php)
 - 2026-05-29 ai-wip: add .github/dependabot.yml for GitHub Actions auto-updates
 - 2026-05-29 fix(ci): smarter change-file validator + per-repo excludes
-- 2026-05-29 fix(ci): smarter change-file validator + per-repo excludes


### PR DESCRIPTION
The line `- 2026-05-29 fix(ci): smarter change-file validator + per-repo excludes` appears **twice, on adjacent lines**, in the same `## [1.0.0]` section — identical text, so neither copy reads as wrong on its own.

Found by the changelog duplicate-entry guard being rolled out org-wide ([github-spine#76](https://github.com/gasyoun/github-spine/pull/76)). The same line is duplicated in **7** dictionary repos (AP, AP90, DCS, FRI, GRA, MD, PWK) — what a shared scaffold emitting it twice looks like.

Both copies sit in one section at the same position, so there is no attribution question: one is deleted. The repo then passes the guard and receives it on the next deploy run.

Per H1850.

🤖 Generated with [Claude Code](https://claude.com/claude-code)